### PR TITLE
Use animation-delay property

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,9 @@ npm install css-animation-sync --save
 
 # API
 
-* `const animation = new sync(animationName [, options])` - Synchronises all DOM elements using a CSS animation
+* `const animation = new sync(animationName)` - Synchronises all DOM elements using a CSS animation
 
     * `animationName` Name of the CSS animation to sync
-
-    Options;
-    * `graceful`: `true` - Increase the speed of the first iteration of an elements animation, to give a smooth initial synchronisation
 
 
     Returns an animation instance (see below)

--- a/src/sync.js
+++ b/src/sync.js
@@ -1,26 +1,15 @@
 
-const defaultOptions = {
-    graceful: true
-};
-
-export default function sync(animationName, options = {}) {
-    const opts = {
-        ...defaultOptions,
-        ...options
-    };
-
+export default function sync(animationName) {
     const elements = new Set();
     let eventTime;
     let lastInterationTS = now();
-    let interationDuration = 0;
 
     function animationStart(event) {
         if (event.animationName === animationName) {
             const el = event.target;
 
-            if (opts.graceful && !elements.has(el) && interationDuration !== 0) {
-                gracefulStart(el, interationDuration, lastInterationTS);
-            }
+            const passed = now() - lastInterationTS;
+            el.style.setProperty('animation-delay', `${-passed}ms`);
 
             elements.add(el);
         }
@@ -32,7 +21,6 @@ export default function sync(animationName, options = {}) {
 
             requestAnimationFrame(frameTime => {
                 if (frameTime !== eventTime) {
-                    interationDuration = now() - lastInterationTS;
                     lastInterationTS = now();
                     restart(elements);
                 }
@@ -101,12 +89,6 @@ function restart(elements) {
             }
         });
     });
-}
-
-
-function gracefulStart(el, interationDuration, lastInterationTS) {
-    const remaining = interationDuration - (now() - lastInterationTS);
-    el.style.setProperty('animation-duration', remaining);
 }
 
 


### PR DESCRIPTION
My use case for this library involves an animation duration of `90s`; synchronization works properly, but the delay is obviously quite noticeable.  My solution is to use the `animation-delay` CSS property with a negative value for any newly animated elements.  It seems like this will work for all other use cases, including the spinner example.

I think this makes the `graceful` option obsolete as well.